### PR TITLE
Segeration between ListRequestObj & RequestObj, Go SDK Gen

### DIFF
--- a/src/main/java/com/chargebee/openapi/Resource.java
+++ b/src/main/java/com/chargebee/openapi/Resource.java
@@ -11,7 +11,6 @@ import com.chargebee.sdk.DataType;
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.Streams;
 import io.swagger.v3.oas.models.media.ArraySchema;
-import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.util.*;
 import java.util.stream.Collectors;

--- a/src/main/java/com/chargebee/sdk/dotnet/Dotnet.java
+++ b/src/main/java/com/chargebee/sdk/dotnet/Dotnet.java
@@ -34,7 +34,7 @@ public class Dotnet extends Language {
   List<Resource> resourceList = new ArrayList<>();
   List<Enum> globalEnums;
 
-  protected final String[] hiddenOverride = { "media", "non_subscription"};
+  protected final String[] hiddenOverride = {"media", "non_subscription"};
 
   @Override
   public List<FileOp> generateSDK(String outputDirectoryPath, Spec spec) throws IOException {
@@ -319,7 +319,8 @@ public class Dotnet extends Language {
       operationRequest.setHasBatch(action.isBatch());
       operationRequest.setPostOperationWithFilter(
           action.hasPostActionContainingFilterAsBodyParams());
-      // Don't hide operations that have subDomain - they need specific request classes for fluent chaining
+      // Don't hide operations that have subDomain - they need specific request classes for fluent
+      // chaining
       if (operationRequest.canHide() && action.subDomain() == null) continue;
       operationRequests.add(operationRequest);
     }
@@ -716,7 +717,8 @@ public class Dotnet extends Language {
 
   public String getReqCreationCode(Action action) {
     boolean isCodeGen = isCodeGen(action);
-    // Generate specific request class if action needs input object OR has subDomain (for fluent chaining)
+    // Generate specific request class if action needs input object OR has subDomain (for fluent
+    // chaining)
     if ((action.isInputObjNeeded() && isCodeGen) || action.subDomain() != null) {
       StringBuilder buf = new StringBuilder();
       buf.append("return new ").append(getClazName(action)).append("(url");
@@ -796,7 +798,8 @@ public class Dotnet extends Language {
 
   private String getRetType(Action action) {
     boolean isCodeGen = isCodeGen(action);
-    // Generate specific request class if action needs input object OR has subDomain (for fluent chaining)
+    // Generate specific request class if action needs input object OR has subDomain (for fluent
+    // chaining)
     if ((action.isInputObjNeeded() && isCodeGen) || action.subDomain() != null) {
       return getClazName(action);
     } else {

--- a/src/main/resources/templates/go/actions.go.hbs
+++ b/src/main/resources/templates/go/actions.go.hbs
@@ -18,7 +18,7 @@ import ({{#if isEvent}}
     "time"{{/if}}
 )
 {{#each actions}}
-func {{goActionName}}({{#if hasPathParameters}}id string{{/if}}{{#or hasRequestBodyParameters hasQueryParameters}}{{#if hasPathParameters}}, {{/if}}params *{{golangCase ../name}}.{{camelCaseToPascalCase goParamName}}RequestParams{{/or}}) chargebee.{{#if isListResourceAction}}List{{/if}}RequestObj {
+func {{goActionName}}({{#if hasPathParameters}}id string{{/if}}{{#or hasRequestBodyParameters hasQueryParameters}}{{#if hasPathParameters}}, {{/if}}params *{{golangCase ../name}}.{{camelCaseToPascalCase goParamName}}RequestParams{{/or}}) chargebee.{{#if isListResourceAction}}List{{/if}}Request {
     return chargebee.Send{{#if isOperationNeedsJsonInput}}JsonRequest{{/if}}{{#if isListResourceAction}}List{{/if}}("{{httpRequestType}}", fmt.Sprintf("/{{urlPrefix}}{{#if hasPathParameters}}/%v{{/if}}{{#if urlSuffix}}/{{urlSuffix}}{{/if}}"{{#if hasPathParameters}}, url.PathEscape(id){{/if}}), {{#or hasRequestBodyParameters hasQueryParameters}}params{{else}}nil{{/or}}){{#if subDomain}}.SetSubDomain("{{subDomain}}"){{/if}}{{#if options.isIdempotent}}.SetIdempotency({{options.isIdempotent}}){{/if}}
 }{{/each}}{{#if isExport}}{{{includeFile "src/main/resources/templates/go/export.go.hbs"}}}{{/if}}{{#if isTimeMachine}}
 {{{includeFile "src/main/resources/templates/go/timeMachine.go.hbs"}}}{{/if}}{{#if isEvent}}
@@ -26,11 +26,11 @@ func {{goActionName}}({{#if hasPathParameters}}id string{{/if}}{{#or hasRequestB
 {{{includeFile "src/main/resources/templates/go/hostedPage.go.hbs"}}}{{/if}}{{#if isSession}}
 {{{includeFile "src/main/resources/templates/go/session.go.hbs"}}}{{/if}}{{#if (eq name "PaymentVoucher")}}
 // Deprecated: This function is deprecated. Please use PaymentVouchersForInvoice instead.
-func Payment_vouchersForInvoice(id string, params *paymentvoucher.PaymentVouchersForInvoiceRequestParams) chargebee.ListRequestObj {
+func Payment_vouchersForInvoice(id string, params *paymentvoucher.PaymentVouchersForInvoiceRequestParams) chargebee.ListRequest {
     return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/payment_vouchers", url.PathEscape(id)), params)
 }
 // Deprecated: This function is deprecated. Please use PaymentVouchersForCustomer instead. 
-func Payment_vouchersForCustomer(id string, params *paymentvoucher.PaymentVouchersForCustomerRequestParams) chargebee.ListRequestObj {
+func Payment_vouchersForCustomer(id string, params *paymentvoucher.PaymentVouchersForCustomerRequestParams) chargebee.ListRequest {
     return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/payment_vouchers", url.PathEscape(id)), params)
 }
 {{/if}}

--- a/src/main/resources/templates/go/actions.go.hbs
+++ b/src/main/resources/templates/go/actions.go.hbs
@@ -18,7 +18,7 @@ import ({{#if isEvent}}
     "time"{{/if}}
 )
 {{#each actions}}
-func {{goActionName}}({{#if hasPathParameters}}id string{{/if}}{{#or hasRequestBodyParameters hasQueryParameters}}{{#if hasPathParameters}}, {{/if}}params *{{golangCase ../name}}.{{camelCaseToPascalCase goParamName}}RequestParams{{/or}}) chargebee.RequestObj {
+func {{goActionName}}({{#if hasPathParameters}}id string{{/if}}{{#or hasRequestBodyParameters hasQueryParameters}}{{#if hasPathParameters}}, {{/if}}params *{{golangCase ../name}}.{{camelCaseToPascalCase goParamName}}RequestParams{{/or}}) chargebee.{{#if isListResourceAction}}List{{/if}}RequestObj {
     return chargebee.Send{{#if isOperationNeedsJsonInput}}JsonRequest{{/if}}{{#if isListResourceAction}}List{{/if}}("{{httpRequestType}}", fmt.Sprintf("/{{urlPrefix}}{{#if hasPathParameters}}/%v{{/if}}{{#if urlSuffix}}/{{urlSuffix}}{{/if}}"{{#if hasPathParameters}}, url.PathEscape(id){{/if}}), {{#or hasRequestBodyParameters hasQueryParameters}}params{{else}}nil{{/or}}){{#if subDomain}}.SetSubDomain("{{subDomain}}"){{/if}}{{#if options.isIdempotent}}.SetIdempotency({{options.isIdempotent}}){{/if}}
 }{{/each}}{{#if isExport}}{{{includeFile "src/main/resources/templates/go/export.go.hbs"}}}{{/if}}{{#if isTimeMachine}}
 {{{includeFile "src/main/resources/templates/go/timeMachine.go.hbs"}}}{{/if}}{{#if isEvent}}
@@ -26,11 +26,11 @@ func {{goActionName}}({{#if hasPathParameters}}id string{{/if}}{{#or hasRequestB
 {{{includeFile "src/main/resources/templates/go/hostedPage.go.hbs"}}}{{/if}}{{#if isSession}}
 {{{includeFile "src/main/resources/templates/go/session.go.hbs"}}}{{/if}}{{#if (eq name "PaymentVoucher")}}
 // Deprecated: This function is deprecated. Please use PaymentVouchersForInvoice instead.
-func Payment_vouchersForInvoice(id string, params *paymentvoucher.PaymentVouchersForInvoiceRequestParams) chargebee.RequestObj {
+func Payment_vouchersForInvoice(id string, params *paymentvoucher.PaymentVouchersForInvoiceRequestParams) chargebee.ListRequestObj {
     return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/payment_vouchers", url.PathEscape(id)), params)
 }
 // Deprecated: This function is deprecated. Please use PaymentVouchersForCustomer instead. 
-func Payment_vouchersForCustomer(id string, params *paymentvoucher.PaymentVouchersForCustomerRequestParams) chargebee.RequestObj {
+func Payment_vouchersForCustomer(id string, params *paymentvoucher.PaymentVouchersForCustomerRequestParams) chargebee.ListRequestObj {
     return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/payment_vouchers", url.PathEscape(id)), params)
 }
 {{/if}}

--- a/src/test/java/com/chargebee/sdk/go/GoTests.java
+++ b/src/test/java/com/chargebee/sdk/go/GoTests.java
@@ -214,10 +214,10 @@ public class GoTests extends LanguageTests {
         writeStringFileOp,
         FileOp.fetchFileContent("src/test/java/com/chargebee/sdk/go/samples/customers_imports.txt"),
         """
-func Create(params *customer.CreateRequestParams) chargebee.RequestObj {
+func Create(params *customer.CreateRequestParams) chargebee.Request {
     return chargebee.Send("POST", fmt.Sprintf("/customers"), params)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
     return chargebee.Send("GET", fmt.Sprintf("/customers/%v", url.PathEscape(id)), nil)
 }""");
   }
@@ -370,7 +370,7 @@ func Retrieve(id string) chargebee.RequestObj {
             "github.com/chargebee/chargebee-go/v3/models/customer"
         )
         """,
-        "func Create(params *customer.CreateRequestParams) chargebee.RequestObj {");
+        "func Create(params *customer.CreateRequestParams) chargebee.Request {");
   }
 
   @Test
@@ -398,7 +398,7 @@ func Retrieve(id string) chargebee.RequestObj {
             "github.com/chargebee/chargebee-go/v3/models/customer"
         )
         """,
-        "func List(params *customer.ListRequestParams) chargebee.ListRequestObj {");
+        "func List(params *customer.ListRequestParams) chargebee.ListRequest {");
   }
 
   @Test
@@ -424,7 +424,7 @@ func Retrieve(id string) chargebee.RequestObj {
         writeStringFileOp,
         FileOp.fetchFileContent("src/test/java/com/chargebee/sdk/go/samples/customers_imports.txt"),
         """
-func Update(id string, params *customer.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *customer.UpdateRequestParams) chargebee.Request {
     return chargebee.Send("POST", fmt.Sprintf("/customers/%v", url.PathEscape(id)), params)
 }""");
   }
@@ -457,7 +457,7 @@ func Update(id string, params *customer.UpdateRequestParams) chargebee.RequestOb
         )
         """,
         """
-        func Create(params *customer.CreateRequestParams) chargebee.RequestObj {
+        func Create(params *customer.CreateRequestParams) chargebee.Request {
             return chargebee.Send("POST", fmt.Sprintf("/customers"), params)
         }""");
   }
@@ -485,7 +485,7 @@ func Update(id string, params *customer.UpdateRequestParams) chargebee.RequestOb
         writeStringFileOp,
         FileOp.fetchFileContent("src/test/java/com/chargebee/sdk/go/samples/customers_imports.txt"),
         """
-func Update(id string, params *customer.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *customer.UpdateRequestParams) chargebee.Request {
     return chargebee.Send("POST", fmt.Sprintf("/customers/%v", url.PathEscape(id)), params)
 }""");
   }
@@ -514,7 +514,7 @@ func Update(id string, params *customer.UpdateRequestParams) chargebee.RequestOb
         writeStringFileOp,
         FileOp.fetchFileContent("src/test/java/com/chargebee/sdk/go/samples/customers_imports.txt"),
         """
-func UpdateBillingInfo(id string, params *customer.UpdateBillingInfoRequestParams) chargebee.RequestObj {
+func UpdateBillingInfo(id string, params *customer.UpdateBillingInfoRequestParams) chargebee.Request {
     return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_billing_info", url.PathEscape(id)), params)
 }""");
   }
@@ -551,10 +551,10 @@ func UpdateBillingInfo(id string, params *customer.UpdateBillingInfoRequestParam
         writeStringFileOp,
         FileOp.fetchFileContent("src/test/java/com/chargebee/sdk/go/samples/customers_imports.txt"),
         """
-func UpdateBillingInfo(id string, params *customer.UpdateBillingInfoRequestParams) chargebee.RequestObj {
+func UpdateBillingInfo(id string, params *customer.UpdateBillingInfoRequestParams) chargebee.Request {
     return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_billing_info", url.PathEscape(id)), params)
 }
-func Hierarchy(id string, params *customer.HierarchyRequestParams) chargebee.RequestObj {
+func Hierarchy(id string, params *customer.HierarchyRequestParams) chargebee.Request {
     return chargebee.Send("GET", fmt.Sprintf("/customers/%v/hierarchy", url.PathEscape(id)), params)
 }""");
   }
@@ -586,7 +586,7 @@ func Hierarchy(id string, params *customer.HierarchyRequestParams) chargebee.Req
         )
         """,
         """
-        func List(params *customer.ListRequestParams) chargebee.ListRequestObj {
+        func List(params *customer.ListRequestParams) chargebee.ListRequest {
             return chargebee.SendList("GET", fmt.Sprintf("/customers"), params)
         }""");
   }

--- a/src/test/java/com/chargebee/sdk/go/GoTests.java
+++ b/src/test/java/com/chargebee/sdk/go/GoTests.java
@@ -398,7 +398,7 @@ func Retrieve(id string) chargebee.RequestObj {
             "github.com/chargebee/chargebee-go/v3/models/customer"
         )
         """,
-        "func List(params *customer.ListRequestParams) chargebee.RequestObj {");
+        "func List(params *customer.ListRequestParams) chargebee.ListRequestObj {");
   }
 
   @Test
@@ -586,7 +586,7 @@ func Hierarchy(id string, params *customer.HierarchyRequestParams) chargebee.Req
         )
         """,
         """
-        func List(params *customer.ListRequestParams) chargebee.RequestObj {
+        func List(params *customer.ListRequestParams) chargebee.ListRequestObj {
             return chargebee.SendList("GET", fmt.Sprintf("/customers"), params)
         }""");
   }
@@ -1839,23 +1839,23 @@ type Result struct {
          type ListAutoCollectionParams struct {
 
          }
-         
+
          type ListAutoCloseInvoicesParams struct {
 
          }
-         
+
          type ListCreatedAtParams struct {
 
          }
-         
+
          type ListSortByParams struct {
-         
+
          }
-         
+
          type ListFirstNameParams struct {
 
          }
-         
+
 
         """);
   }

--- a/src/test/java/com/chargebee/sdk/go/samples/events.txt
+++ b/src/test/java/com/chargebee/sdk/go/samples/events.txt
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/events/%v", url.PathEscape(id)), nil)
 }
 func Content(event event.Event) *chargebee.Result {

--- a/src/test/java/com/chargebee/sdk/go/samples/exports.txt
+++ b/src/test/java/com/chargebee/sdk/go/samples/exports.txt
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/exports/%v", url.PathEscape(id)), nil)
 }
 func WaitForExportCompletionWithEnv(exp export.Export, env chargebee.Environment) (export.Export, error) {

--- a/src/test/java/com/chargebee/sdk/go/samples/hostedPages.txt
+++ b/src/test/java/com/chargebee/sdk/go/samples/hostedPages.txt
@@ -8,7 +8,7 @@ import (
 	"net/url"
 )
 
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/hosted_pages/%v", url.PathEscape(id)), nil)
 }
 func Content(page hostedpage.HostedPage) *chargebee.Result {

--- a/src/test/java/com/chargebee/sdk/go/samples/timeMachine.txt
+++ b/src/test/java/com/chargebee/sdk/go/samples/timeMachine.txt
@@ -11,7 +11,7 @@ import (
 	"net/url"
 )
 
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/time_machines/%v", url.PathEscape(id)), nil)
 }
 func WaitForTimeTravelCompletion(tm timemachine.TimeMachine) (timemachine.TimeMachine, error) {


### PR DESCRIPTION
## 📘 Description
This PR introduces the clear segeration between Response Object and ListResponse Object in GO SDK, previously both were working at the compile time making it confusing for developers. 
<!-- Provide a concise and clear explanation of what this PR does. Focus on **what** and **why**, rather than **how**. For example: -->
<!-- "This PR introduces support for retry logic in generated Python SDKs, aligning with Chargebee’s latest API guidelines." -->

## 📂 Type of Change

<!-- Select all that apply -->
- [x] ✨ Feature  
- [ ] 🐛 Bug Fix  
- [ ] 📝 Documentation  
- [ ] 🧪 Test Improvement  
- [ ] 🔧 Refactor / Code Cleanup  
- [ ] ⚙️ Build / Tooling  

## 🧪 How to Test
You can utilize the following codes and it will work, inter changing ListRequest() with Request() will now throw compilation error. 
<!-- Briefly describe how reviewers can test your changes. Include setup steps, CLI commands, or code snippets where relevant. -->
```Go
listCustomerResponse, errList := customerAction.List(params).ListRequest()
retrieveCustomerResponse, errRetrieve := customerAction.Retrieve("{customer-id}").Request()
```

https://github.com/user-attachments/assets/726515ac-aa6f-4495-a4f9-44e1f86eb97f

