### PR TITLE
Bug fix: PHP v4 gen empty response case

### DIFF
--- a/src/main/java/com/chargebee/sdk/php/v4/ResponseParser.java
+++ b/src/main/java/com/chargebee/sdk/php/v4/ResponseParser.java
@@ -14,6 +14,15 @@ public class ResponseParser {
   public static com.chargebee.sdk.php.v4.models.Resource actionResponses(
       Action action, Resource res) {
     Schema<?> successSchema = action.getOnSuccessSchema();
+    if (successSchema == null) {
+      com.chargebee.sdk.php.v4.models.Resource response =
+          new com.chargebee.sdk.php.v4.models.Resource();
+      response.setClazName(toCamelCase(action.name) + res.name + "Response");
+      response.setNamespace(RESPONSE_NAMESPACE + toCamelCase(res.name) + "Response");
+      response.setCols(new ArrayList<>());
+      response.setImports(collectImports(response.getCols()));
+      return response;
+    }
     if (successSchema.getProperties() == null) {
       return null;
     }


### PR DESCRIPTION
# 🚀 Pull Request Template

## 📘 Description

In php v4 SDK if the response if 204 the SDK generation was failing. 

## 🧩 Related Issues / Tickets

<!-- Reference any related issues or feature requests. Use "Closes #..." to auto-close the issue on merge. -->
Closes #IssueNumber

## 📂 Type of Change

<!-- Select all that apply -->
- [ ] ✨ Feature  
- [ ] 🐛 Bug Fix  
- [ ] 📝 Documentation  
- [ ] 🧪 Test Improvement  
- [ ] 🔧 Refactor / Code Cleanup  
- [ ] ⚙️ Build / Tooling  

## 🧪 How to Test

<!-- Briefly describe how reviewers can test your changes. Include setup steps, CLI commands, or code snippets where relevant. -->

```bash
# Example:
./gradlew run --args="-i spec.json -l PHP_V4 -o ../chargebee-php/php/src"