### PR TITLE
fix(php): correct enum typing for sub-resource properties

### DIFF
--- a/src/main/java/com/chargebee/sdk/php/v4/Common.java
+++ b/src/main/java/com/chargebee/sdk/php/v4/Common.java
@@ -1,7 +1,6 @@
 package com.chargebee.sdk.php.v4;
 
-import static com.chargebee.GenUtil.singularize;
-import static com.chargebee.GenUtil.toCamelCase;
+import static com.chargebee.GenUtil.*;
 import static com.chargebee.openapi.Extension.SDK_ENUM_API_NAME;
 import static com.chargebee.openapi.Extension.SUB_RESOURCE_NAME;
 import static com.chargebee.openapi.Resource.*;
@@ -16,6 +15,7 @@ import io.swagger.v3.oas.models.media.*;
 public class Common {
 
   public static final String CHARGEBEE_ENUMS_BASE_PATH = "\\Chargebee\\Enums\\";
+
   public static final String CHARGEBEE_RESOURCES_BASE_PATH = "\\Chargebee\\Resources\\";
   public static final String ENUMS_DIRECTORY = "Enums";
 
@@ -159,6 +159,51 @@ public class Common {
         attribute, CHARGEBEE_ENUMS_BASE_PATH, String.format("%sType", singularize(type)));
   }
 
+  public static Column globalEnumsForSubResources(Attribute attribute) {
+    return createEnumColumn(attribute, CHARGEBEE_ENUMS_BASE_PATH);
+  }
+
+  public static Column localEnumsForSubResources(
+      Attribute attribute, Resource res, Attribute subResourceAttribute) {
+    String type;
+    String resourceName = res.name;
+
+    if (subResourceAttribute.isDependentAttribute() || attribute.isDependentAttribute()) {
+      type = toCamelCase(res.name) + toCamelCase(attribute.name);
+    } else {
+      if (attribute.isExternalEnum()) {
+        if (attribute.getEnumApiName() == null
+            || attribute.getEnumApiName().equalsIgnoreCase(attribute.name)) {
+          type = toCamelCase(attribute.name);
+        } else {
+          type = firstCharLower(attribute.getEnumApiName());
+          resourceName = attribute.getEnumApiName();
+          type =
+              type.contains(".")
+                  ? type.substring(type.lastIndexOf('.') + 1)
+                  : toCamelCase(attribute.name);
+          resourceName =
+              resourceName.contains(".")
+                  ? resourceName.substring(0, resourceName.lastIndexOf('.'))
+                  : "";
+        }
+      } else {
+        type = subResourceName(subResourceAttribute, attribute);
+      }
+    }
+    String basePath;
+    // When an enum is marked as external but has no external reference in the OpenAPI specs,
+    // it is treated as a global enum.
+    if (resourceName.equals("")) {
+      basePath = CHARGEBEE_ENUMS_BASE_PATH;
+    } else {
+      basePath =
+          CHARGEBEE_RESOURCES_BASE_PATH + resourceName + BACK_SLASH + ENUMS_DIRECTORY + BACK_SLASH;
+    }
+
+    return createEnumColumn(attribute, basePath, type);
+  }
+
   public static Column localEnumParser(Attribute attribute, Resource res) {
     return createEnumColumn(
         attribute,
@@ -179,12 +224,12 @@ public class Common {
     return column;
   }
 
-  private static Column createEnumColumn(
-      Attribute attribute, String basePath, String fieldTypePHP) {
+  private static Column createEnumColumn(Attribute attribute, String basePath, String type) {
+    String enumType = basePath + type;
     Column column = new Column();
     column.setName(attribute.name);
-    column.setFieldTypePHP(basePath + fieldTypePHP);
-    column.setPhpDocField(basePath + fieldTypePHP);
+    column.setFieldTypePHP(enumType);
+    column.setPhpDocField(enumType);
     column.setIsOptional(true);
     column.setApiName(attribute.name);
     return column;
@@ -195,5 +240,12 @@ public class Common {
         + subResourceName(schema)
         + BACK_SLASH
         + subResourceName(schema);
+  }
+
+  private static String subResourceName(Attribute subResourceAttribute, Attribute attribute) {
+    if (subResourceAttribute.subResourceName() != null) {
+      return subResourceAttribute.subResourceName() + toCamelCase(attribute.name);
+    }
+    return singularize(toCamelCase(subResourceAttribute.name)) + toCamelCase(attribute.name);
   }
 }

--- a/src/main/java/com/chargebee/sdk/php/v4/SubResourceParser.java
+++ b/src/main/java/com/chargebee/sdk/php/v4/SubResourceParser.java
@@ -1,14 +1,18 @@
 package com.chargebee.sdk.php.v4;
 
 import static com.chargebee.GenUtil.*;
+import static com.chargebee.sdk.php.v4.Common.localEnumsForSubResources;
 
 import com.chargebee.openapi.Attribute;
 import com.chargebee.openapi.Resource;
 import com.chargebee.sdk.common.ResourceAssist;
 import com.chargebee.sdk.php.v4.models.Column;
 import io.swagger.v3.oas.models.media.ArraySchema;
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class SubResourceParser {
   public static List<com.chargebee.sdk.php.v4.models.Resource> listSubResources(
@@ -16,13 +20,13 @@ public class SubResourceParser {
     return new ResourceAssist()
         .setResource(activeResource).subResource().stream()
             .filter(SubResourceParser::isValidSubResource)
-            .map(SubResourceParser::createSubResource)
+            .map(attribute -> createSubResource(attribute, activeResource))
             .collect(Collectors.toList());
   }
 
   public static List<Column> getSubResourceCols(Attribute subResourceAttribute) {
     return subResourceAttribute.attributes().stream()
-        .filter(Attribute::isNotHiddenAttribute)
+        .filter(attribute -> attribute.isNotHiddenAttribute() && !attribute.isEnumAttribute())
         .map(Common::columnParser)
         .collect(Collectors.toList());
   }
@@ -33,11 +37,25 @@ public class SubResourceParser {
         && !Resource.isGlobalResourceReference(attribute.schema);
   }
 
-  private static com.chargebee.sdk.php.v4.models.Resource createSubResource(Attribute attribute) {
+  private static com.chargebee.sdk.php.v4.models.Resource createSubResource(
+      Attribute attribute, Resource activeResource) {
     com.chargebee.sdk.php.v4.models.Resource subResource =
         new com.chargebee.sdk.php.v4.models.Resource();
     subResource.setClazName(determineClassName(attribute));
     subResource.setCols(getSubResourceCols(attribute));
+    subResource.setGlobalEnumCols(generateGlobalEnumsForSubResources(attribute));
+    subResource.setLocalEnumCols(generateLocalEnumsForSubResources(attribute, activeResource));
+    List<String> knownFields =
+        Stream.of(
+                subResource.getCols(),
+                subResource.getGlobalEnumCols(),
+                subResource.getLocalEnumCols(),
+                subResource.getListOfEnumCols())
+            .filter(Objects::nonNull)
+            .flatMap(Collection::stream)
+            .map(Column::getApiName)
+            .collect(Collectors.toList());
+    subResource.setKnownFields(knownFields);
     return subResource;
   }
 
@@ -45,5 +63,28 @@ public class SubResourceParser {
     return attribute.schema instanceof ArraySchema
         ? singularize(toClazName(attribute.name))
         : attribute.subResourceName();
+  }
+
+  public static List<Column> generateGlobalEnumsForSubResources(Attribute subResourceAttribute) {
+    return subResourceAttribute.attributes().stream()
+        .filter(
+            attribute ->
+                attribute.isNotHiddenAttribute()
+                    && attribute.isEnumAttribute()
+                    && (attribute.isGlobalEnumAttribute() || attribute.isGenSeparate()))
+        .map(Common::globalEnumsForSubResources)
+        .collect(Collectors.toList());
+  }
+
+  public static List<Column> generateLocalEnumsForSubResources(
+      Attribute subResourceAttribute, Resource res) {
+    return subResourceAttribute.attributes().stream()
+        .filter(
+            attribute ->
+                attribute.isNotHiddenAttribute()
+                    && attribute.isEnumAttribute()
+                    && !(attribute.isGlobalEnumAttribute() || attribute.isGenSeparate()))
+        .map(attribute -> localEnumsForSubResources(attribute, res, subResourceAttribute))
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/chargebee/sdk/php/v4/models/Resource.java
+++ b/src/main/java/com/chargebee/sdk/php/v4/models/Resource.java
@@ -13,4 +13,5 @@ public class Resource {
   private String namespace;
   private List<String> imports;
   private boolean isCustomFieldSupported;
+  private List<String> knownFields;
 }

--- a/src/main/resources/templates/php/v4/listResponse.php.hbs
+++ b/src/main/resources/templates/php/v4/listResponse.php.hbs
@@ -1,8 +1,7 @@
 <?php
 
 {{#if namespace}}namespace {{namespace}};{{/if}}
-{{#each imports}}{{.}};
-{{/each}}
+{{#each imports}}{{.}};{{/each}}
 use Chargebee\ValueObjects\ResponseBase;
 
 class {{clazName}} extends ResponseBase {{curly "open"}} {{#each cols}}

--- a/src/main/resources/templates/php/v4/resource.php.hbs
+++ b/src/main/resources/templates/php/v4/resource.php.hbs
@@ -33,7 +33,7 @@ class {{clazName}} {{#if customFieldSupported}} extends SupportsCustomFields {{/
     /**
     * @var array<string> $knownFields
     */
-    protected static array $knownFields = [{{#each cols}} "{{apiName}}" {{#unless @last}},{{/unless}}{{/each}} ];
+    protected static array $knownFields = [{{#each knownFields}} "{{{.}}}" {{#unless @last}},{{/unless}}{{/each}} ];
 
     /**
     * dynamic properties for resources


### PR DESCRIPTION
# 🚀 Pull Request Template

## 📘 Description

Enum conversion was previously applied only to first-level resource properties.
Several enum-backed fields inside sub-resources were left as string, leading to inconsistent typing across the SDK.

This release fixes that gap and brings sub-resource fields in line with the rest of the SDK.


## 🧩 Related Issues / Tickets
https://github.com/chargebee/chargebee-php/issues/96

## 📂 Type of Change

<!-- Select all that apply -->
- [ ] ✨ Feature  
- [x] 🐛 Bug Fix  
- [ ] 📝 Documentation  
- [ ] 🧪 Test Improvement  
- [ ] 🔧 Refactor / Code Cleanup  
- [ ] ⚙️ Build / Tooling  