### PR TITLE
Fixed the filter type issue for the java v3 gen and dotnet v3

### DIFF
--- a/src/main/java/com/chargebee/sdk/dotnet/ReturnTypeBuilder.java
+++ b/src/main/java/com/chargebee/sdk/dotnet/ReturnTypeBuilder.java
@@ -80,6 +80,30 @@ public class ReturnTypeBuilder {
         && attribute.attributes().get(0).schema.getFormat().equals("boolean");
   }
 
+  private String filterString() {
+    if (attribute.isFilterAttribute()
+        && dataTypeMethod.apply(attribute.schema).equalsIgnoreCase("StringFilter")) {
+      return getClazName(action);
+    }
+    return null;
+  }
+
+  private String filterBoolean() {
+    if (attribute.isFilterAttribute()
+        && dataTypeMethod.apply(attribute.schema).equalsIgnoreCase("BooleanFilter")) {
+      return getClazName(action);
+    }
+    return null;
+  }
+
+  private String filterTimestamp() {
+    if (attribute.isFilterAttribute()
+        && dataTypeMethod.apply(attribute.schema).equalsIgnoreCase("TimestampFilter")) {
+      return getClazName(action);
+    }
+    return null;
+  }
+
   public String returnTypeWithoutAttribute() {
     if (isBooleanAttribute()) {
       return getClazName(action);
@@ -124,6 +148,22 @@ public class ReturnTypeBuilder {
   }
 
   public String build() {
+    // Check for filter types first - they should only have the request class as generic parameter
+    String filterString = filterString();
+    if (filterString != null) {
+      return filterString;
+    }
+
+    String filterBoolean = filterBoolean();
+    if (filterBoolean != null) {
+      return filterBoolean;
+    }
+
+    String filterTimestamp = filterTimestamp();
+    if (filterTimestamp != null) {
+      return filterTimestamp;
+    }
+
     String returnTypeWithoutSubAttribute = returnTypeWithoutAttribute();
     if (returnTypeWithoutSubAttribute != null) {
       return returnTypeWithoutSubAttribute;

--- a/src/main/java/com/chargebee/sdk/java/ReturnTypeBuilder.java
+++ b/src/main/java/com/chargebee/sdk/java/ReturnTypeBuilder.java
@@ -307,6 +307,22 @@ public class ReturnTypeBuilder {
     return null;
   }
 
+  private String filterString(Attribute attribute) {
+    if (attribute.isFilterAttribute()
+        && dataTypeMethod.apply(attribute.schema).equalsIgnoreCase("StringFilter")) {
+      return getClazName(action);
+    }
+    return null;
+  }
+
+  private String filterBoolean(Attribute attribute) {
+    if (attribute.isFilterAttribute()
+        && dataTypeMethod.apply(attribute.schema).equalsIgnoreCase("BooleanFilter")) {
+      return getClazName(action);
+    }
+    return null;
+  }
+
   private String resourceLevelMultiAttribute(Attribute attribute) {
     if (!attribute.attributes().isEmpty()) {
       Optional<Resource> resource =
@@ -393,6 +409,16 @@ public class ReturnTypeBuilder {
     String filterTimestamp = filterTimestamp(attribute);
     if (filterTimestamp != null) {
       return filterTimestamp;
+    }
+
+    String filterString = filterString(attribute);
+    if (filterString != null) {
+      return filterString;
+    }
+
+    String filterBoolean = filterBoolean(attribute);
+    if (filterBoolean != null) {
+      return filterBoolean;
     }
 
     String resourceLevelMultiAttribute = resourceLevelMultiAttribute(attribute);


### PR DESCRIPTION
### Before  (Bug) 
```java 
        public StringFilter<String, InvoiceListRequest> exclude() {
            return new StringFilter<String, InvoiceListRequest>("exclude",this).supportsMultiOperators(true);        
        }
```

### After (Correct) 
```java
        public StringFilter<InvoiceListRequest> exclude() {
            return new StringFilter<InvoiceListRequest>("exclude",this).supportsMultiOperators(true);        
        }
```