### PR TITLE
Fix/internal sdk composite array enums

### DIFF
--- a/src/main/java/com/chargebee/sdk/java/Java.java
+++ b/src/main/java/com/chargebee/sdk/java/Java.java
@@ -293,7 +293,13 @@ public class Java extends Language {
             attribute.schema instanceof ArraySchema
                 ? singularize(toClazName(attribute.name))
                 : attribute.subResourceName());
-        subResource.setEnumCols(getSubResourceEnum(attribute));
+        List<EnumColumn> subResourceEnums = new ArrayList<>(getSubResourceEnum(attribute));
+        // Only collect enums from composite array parameters for internal SDK generation
+        if (generationMode.equals(GenerationMode.INTERNAL)) {
+          subResourceEnums.addAll(
+              getCompositeArrayEnumsForSubResource(attribute.name, res, subResourceEnums));
+        }
+        subResource.setEnumCols(subResourceEnums);
         subResource.setSchemaLessEnum(
             SchemaLessEnumParser.getSchemaLessEnumForSubResource(
                 subResource.getClazName(), activeResource));
@@ -302,6 +308,76 @@ public class Java extends Language {
       }
     }
     return subResources;
+  }
+
+  private boolean shouldGenerateEnum(Attribute attribute) {
+    if (!attribute.isEnumAttribute()) return false;
+    if (attribute.isGenSeparate()) return false;
+    if (attribute.isGlobalEnumAttribute()) return false;
+    if (attribute.isExternalEnum()) return false;
+    String enumApiName = attribute.getEnumApiName();
+    if (enumApiName == null && attribute.schema instanceof ArraySchema) {
+      if (attribute.schema.getItems() != null
+          && attribute.schema.getItems().getExtensions() != null) {
+        enumApiName =
+            (String) attribute.schema.getItems().getExtensions().get(Extension.SDK_ENUM_API_NAME);
+      }
+    }
+    return enumApiName != null;
+  }
+
+  private List<EnumColumn> getCompositeArrayEnumsForSubResource(
+      String subResourceAttributeName, Resource res, List<EnumColumn> existingEnums) {
+    List<EnumColumn> enumColumns = new ArrayList<>();
+    for (Action action : res.actions) {
+      for (Parameter iparam : action.requestBodyParameters()) {
+        if (iparam.isCompositeArrayBody() && iparam.getName().equals(subResourceAttributeName)) {
+          Attribute multiAttribute =
+              new Attribute(iparam.getName(), iparam.schema, iparam.isRequired);
+          for (Attribute attribute : multiAttribute.attributes()) {
+            if (!attribute.isNotHiddenAttribute()) continue;
+            if (shouldGenerateEnum(attribute)) {
+              String apiClassName = toClazName(attribute.name);
+              boolean alreadyExists =
+                  existingEnums.stream().anyMatch(e -> e.getApiClassName().equals(apiClassName))
+                      || enumColumns.stream()
+                          .anyMatch(e -> e.getApiClassName().equals(apiClassName));
+              if (!alreadyExists) {
+                EnumColumn enumColumn = new EnumColumn();
+                enumColumn.setDeprecated(attribute.isDeprecated());
+                enumColumn.setVisibleEntries(getEnumEntries(attribute));
+                enumColumn.setApiClassName(apiClassName);
+                enumColumns.add(enumColumn);
+              }
+            }
+          }
+        }
+      }
+      for (Parameter iparam : action.queryParameters()) {
+        if (iparam.isCompositeArrayBody() && iparam.getName().equals(subResourceAttributeName)) {
+          Attribute multiAttribute =
+              new Attribute(iparam.getName(), iparam.schema, iparam.isRequired);
+          for (Attribute attribute : multiAttribute.attributes()) {
+            if (!attribute.isNotHiddenAttribute()) continue;
+            if (shouldGenerateEnum(attribute)) {
+              String apiClassName = toClazName(attribute.name);
+              boolean alreadyExists =
+                  existingEnums.stream().anyMatch(e -> e.getApiClassName().equals(apiClassName))
+                      || enumColumns.stream()
+                          .anyMatch(e -> e.getApiClassName().equals(apiClassName));
+              if (!alreadyExists) {
+                EnumColumn enumColumn = new EnumColumn();
+                enumColumn.setDeprecated(attribute.isDeprecated());
+                enumColumn.setVisibleEntries(getEnumEntries(attribute));
+                enumColumn.setApiClassName(apiClassName);
+                enumColumns.add(enumColumn);
+              }
+            }
+          }
+        }
+      }
+    }
+    return enumColumns;
   }
 
   private String updateForSubAttributes(String colsRetType) {
@@ -574,6 +650,60 @@ public class Java extends Language {
         enumColumn.setVisibleEntries(getEnumEntries(attribute));
         enumColumn.setApiClassName(toClazName(attribute.name));
         enumColumns.add(enumColumn);
+      }
+    }
+    // Only collect enums from composite array parameters for internal SDK generation
+    if (generationMode.equals(GenerationMode.INTERNAL)) {
+      List<String> subResourceAttributeNames =
+          res.getSortedResourceAttributes().stream()
+              .filter(Attribute::isSubResource)
+              .map(attr -> attr.name)
+              .toList();
+      for (Action action : res.actions) {
+        for (Parameter iparam : action.requestBodyParameters()) {
+          if (iparam.isCompositeArrayBody()
+              && !subResourceAttributeNames.contains(iparam.getName())) {
+            Attribute multiAttribute =
+                new Attribute(iparam.getName(), iparam.schema, iparam.isRequired);
+            for (Attribute attribute : multiAttribute.attributes()) {
+              if (!attribute.isNotHiddenAttribute()) continue;
+              if (shouldGenerateEnum(attribute)) {
+                String apiClassName = toClazName(attribute.name);
+                boolean alreadyExists =
+                    enumColumns.stream().anyMatch(e -> e.getApiClassName().equals(apiClassName));
+                if (!alreadyExists) {
+                  EnumColumn enumColumn = new EnumColumn();
+                  enumColumn.setDeprecated(attribute.isDeprecated());
+                  enumColumn.setVisibleEntries(getEnumEntries(attribute));
+                  enumColumn.setApiClassName(apiClassName);
+                  enumColumns.add(enumColumn);
+                }
+              }
+            }
+          }
+        }
+        for (Parameter iparam : action.queryParameters()) {
+          if (iparam.isCompositeArrayBody()
+              && !subResourceAttributeNames.contains(iparam.getName())) {
+            Attribute multiAttribute =
+                new Attribute(iparam.getName(), iparam.schema, iparam.isRequired);
+            for (Attribute attribute : multiAttribute.attributes()) {
+              if (!attribute.isNotHiddenAttribute()) continue;
+              if (shouldGenerateEnum(attribute)) {
+                String apiClassName = toClazName(attribute.name);
+                boolean alreadyExists =
+                    enumColumns.stream().anyMatch(e -> e.getApiClassName().equals(apiClassName));
+                if (!alreadyExists) {
+                  EnumColumn enumColumn = new EnumColumn();
+                  enumColumn.setDeprecated(attribute.isDeprecated());
+                  enumColumn.setVisibleEntries(getEnumEntries(attribute));
+                  enumColumn.setApiClassName(apiClassName);
+                  enumColumns.add(enumColumn);
+                }
+              }
+            }
+          }
+        }
       }
     }
     return enumColumns;


### PR DESCRIPTION
Fix: Generate enums from composite array parameters for internal SDK only

This fix addresses missing enum definitions (e.g., EntityType in
EntitlementOverride) that are referenced in composite array request
body parameters but were not being generated in the Java internal SDK.

Changes:
- Added shouldGenerateEnum() helper to validate enum generation criteria
- Modified getEnumCols() to collect enums from composite array parameters
  that don't have matching subresources (internal mode only)
- Modified getSubResources() to collect enums from composite array
  parameters for subresources (internal mode only)
- Added external enum check to prevent duplicate generation
- Scoped fix to INTERNAL generation mode only (JAVA_INTERNAL_INT,
  JAVA_INTERNAL_INT_V2) - EXTERNAL mode (JAVA_V3) unaffected

The fix ensures proper deduplication by checking against existing
enums collected from subresource attributes.

Fixes: Missing EntityType enum in EntitlementOverride.java
Tested: All 74 Java SDK tests pass, Maven build successful