### PR TITLE
Fix PHP docs URL paths to use x-cb-resource-path-name

### DIFF
--- a/src/main/java/com/chargebee/sdk/php/v4/ActionParser.java
+++ b/src/main/java/com/chargebee/sdk/php/v4/ActionParser.java
@@ -63,7 +63,7 @@ public class ActionParser {
         .setPhpDocField(PHPDocSerializer.serializeActionParameter(action))
         .setActionDocLink(
             API_DOCS_URL
-                + pluralize(res.id)
+                + res.pathName()
                 + '/'
                 + CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_HYPHEN, action.id)
                 + API_DOCS_QUERY)


### PR DESCRIPTION
Fix PHP docs URL paths to use x-cb-resource-path-name