### PR TITLE
internal SDK java compiler error fix

### DIFF
--- a/src/main/java/com/chargebee/sdk/java/v4/builder/ModelBuilder.java
+++ b/src/main/java/com/chargebee/sdk/java/v4/builder/ModelBuilder.java
@@ -108,14 +108,16 @@ public class ModelBuilder {
 
   /**
    * Checks if a model name represents a webhook event.
-   * Webhook events end with "Event" but excludes non-webhook classes like "Event", "UsageEvent", "OfferEvent".
+   * Webhook events end with "Event" but excludes API resource models such as "Event", "UsageEvent",
+   * "OfferEvent", and "FailedUsageEvent".
    */
   private static boolean isWebhookEvent(String modelName) {
     if (modelName == null || !modelName.endsWith("Event")) {
       return false;
     }
-    // Exclude non-webhook event models
-    Set<String> excludedModels = Set.of("Event", "UsageEvent", "OfferEvent");
+    // Exclude API resource models that end with "Event" but are not webhook payloads
+    Set<String> excludedModels =
+        Set.of("Event", "UsageEvent", "OfferEvent", "FailedUsageEvent");
     return !excludedModels.contains(modelName);
   }
 

--- a/src/main/resources/templates/java/next/core.get.response.list.hbs
+++ b/src/main/resources/templates/java/next/core.get.response.list.hbs
@@ -58,7 +58,10 @@ public final class {{name}}Response {
         try {
             JsonObject jsonObj = JsonUtil.parse(json);
             {{#each fields}}
-            {{#if isComplexObjectType}}
+            {{#if isMapType}}
+            JsonObject __{{name}}Obj = JsonUtil.getJsonObject(jsonObj, "{{curlName}}");
+            {{{type}}} {{name}} = __{{name}}Obj != null ? JsonUtil.parseJsonObjectToMap(__{{name}}Obj) : null;
+            {{else if isComplexObjectType}}
             JsonObject __{{name}}Obj = JsonUtil.getJsonObject(jsonObj, "{{curlName}}");
             {{{type}}} {{name}} = __{{name}}Obj != null ? {{{type}}}.fromJson(__{{name}}Obj) : null;
             {{else if isEnumType}}
@@ -90,12 +93,12 @@ public final class {{name}}Response {
             {{{type}}} {{name}} = __{{name}}Arr != null ? JsonUtil.parseArrayOfString(__{{name}}Arr) : null;
             {{/if}}
             {{else if isObjectType}}
-            {{#unless (eq type "Object")}}
+            {{#if isPlainObjectType}}
+            {{{type}}} {{name}} = JsonUtil.getObject(jsonObj, "{{curlName}}");
+            {{else}}
             JsonObject __{{name}}Obj = JsonUtil.getJsonObject(jsonObj, "{{curlName}}");
             {{{type}}} {{name}} = __{{name}}Obj != null ? {{{type}}}.fromJson(__{{name}}Obj) : null;
-            {{else}}
-            {{{type}}} {{name}} = JsonUtil.getObject(jsonObj, "{{curlName}}");
-            {{/unless}}
+            {{/if}}
             {{else}}
             {{{type}}} {{name}} = JsonUtil.get{{{type}}}(jsonObj, "{{curlName}}");
             {{/if}}
@@ -115,7 +118,10 @@ public final class {{name}}Response {
         try {
             JsonObject jsonObj = JsonUtil.parse(json);
             {{#each fields}}
-            {{#if isComplexObjectType}}
+            {{#if isMapType}}
+            JsonObject __{{name}}Obj = JsonUtil.getJsonObject(jsonObj, "{{curlName}}");
+            {{{type}}} {{name}} = __{{name}}Obj != null ? JsonUtil.parseJsonObjectToMap(__{{name}}Obj) : null;
+            {{else if isComplexObjectType}}
             JsonObject __{{name}}Obj = JsonUtil.getJsonObject(jsonObj, "{{curlName}}");
             {{{type}}} {{name}} = __{{name}}Obj != null ? {{{type}}}.fromJson(__{{name}}Obj) : null;
             {{else if isEnumType}}
@@ -147,12 +153,12 @@ public final class {{name}}Response {
             {{{type}}} {{name}} = __{{name}}Arr != null ? JsonUtil.parseArrayOfString(__{{name}}Arr) : null;
             {{/if}}
             {{else if isObjectType}}
-            {{#unless (eq type "Object")}}
+            {{#if isPlainObjectType}}
+            {{{type}}} {{name}} = JsonUtil.getObject(jsonObj, "{{curlName}}");
+            {{else}}
             JsonObject __{{name}}Obj = JsonUtil.getJsonObject(jsonObj, "{{curlName}}");
             {{{type}}} {{name}} = __{{name}}Obj != null ? {{{type}}}.fromJson(__{{name}}Obj) : null;
-            {{else}}
-            {{{type}}} {{name}} = JsonUtil.getObject(jsonObj, "{{curlName}}");
-            {{/unless}}
+            {{/if}}
             {{else}}
             {{{type}}} {{name}} = JsonUtil.get{{{type}}}(jsonObj, "{{curlName}}");
             {{/if}}
@@ -287,14 +293,14 @@ public final class {{name}}Response {
         item.{{name}} = {{{type}}}.fromJson(__{{name}}Obj);
         }
         {{else if isObjectType}}
-        {{#unless (eq type "Object")}}
+        {{#if isPlainObjectType}}
+        item.{{name}} = JsonUtil.getObject(jsonObj, "{{curlName}}");
+        {{else}}
         JsonObject __{{name}}Obj = JsonUtil.getJsonObject(jsonObj, "{{curlName}}");
         if (__{{name}}Obj != null) {
         item.{{name}} = {{{type}}}.fromJson(__{{name}}Obj);
         }
-        {{else}}
-        item.{{name}} = JsonUtil.getObject(jsonObj, "{{curlName}}");
-        {{/unless}}
+        {{/if}}
         {{else if isEnumType}}
         item.{{name}} = {{{type}}}.fromString(JsonUtil.getString(jsonObj, "{{curlName}}"));
         {{else if isListOfObjects}}

--- a/src/main/resources/templates/java/next/core.post.response.hbs
+++ b/src/main/resources/templates/java/next/core.post.response.hbs
@@ -44,7 +44,12 @@ public final class {{name}}Response extends BaseResponse {
             JsonObject jsonObj = JsonUtil.parse(json);
             Builder builder = builder();
             {{#each fields}}
-            {{#if isComplexObjectType}}
+            {{#if isMapType}}
+            JsonObject __{{name}}Obj = JsonUtil.getJsonObject(jsonObj, "{{curlName}}");
+            if (__{{name}}Obj != null) {
+            builder.{{name}}(JsonUtil.parseJsonObjectToMap(__{{name}}Obj));
+            }
+            {{else if isComplexObjectType}}
             JsonObject __{{name}}Obj = JsonUtil.getJsonObject(jsonObj, "{{curlName}}");
             if (__{{name}}Obj != null) {
             builder.{{name}}({{{type}}}.fromJson(__{{name}}Obj));
@@ -79,7 +84,7 @@ public final class {{name}}Response extends BaseResponse {
             }
             {{/if}}
             {{else if isObjectType}}
-            {{#if (eq type "Object")}}
+            {{#if isPlainObjectType}}
             builder.{{name}}(JsonUtil.getObject(jsonObj, "{{curlName}}"));
             {{else}}
             JsonObject __{{name}}Obj = JsonUtil.getJsonObject(jsonObj, "{{curlName}}");

--- a/src/test/java/com/chargebee/sdk/java/v4/builder/PostResponseBuilderTest.java
+++ b/src/test/java/com/chargebee/sdk/java/v4/builder/PostResponseBuilderTest.java
@@ -352,6 +352,27 @@ class PostResponseBuilderTest {
     }
 
     @Test
+    @DisplayName("Should parse map fields using JsonUtil.parseJsonObjectToMap")
+    void shouldParseMapFieldsUsingJsonUtil() throws IOException {
+      ObjectSchema mapSchema = new ObjectSchema();
+      mapSchema.setAdditionalProperties(true);
+
+      ObjectSchema responseSchema = new ObjectSchema();
+      responseSchema.addProperty("error", mapSchema);
+
+      Operation postOp =
+          createPostOperationWithResponse("entitlementOverride", "validate", responseSchema);
+      addPathWithPostOperation("/entitlement_overrides/validate", postOp);
+      responseBuilder.withOutputDirectoryPath(outputPath).withTemplate(mockTemplate);
+
+      List<FileOp> fileOps = responseBuilder.build(openAPI);
+
+      FileOp.WriteString writeOp = findWriteOp(fileOps, "EntitlementOverrideValidateResponse.java");
+      assertThat(writeOp.fileContent).contains("JsonUtil.parseJsonObjectToMap(__errorObj)");
+      assertThat(writeOp.fileContent).doesNotContain("java.util.Map<String, Object>.fromJson");
+    }
+
+    @Test
     @DisplayName("Should generate empty response for schema without properties")
     void shouldGenerateEmptyResponseForSchemaWithoutProperties() throws IOException {
       ObjectSchema responseSchema = new ObjectSchema();


### PR DESCRIPTION
Fixes Java V4 SDK generation issues that broke internal SDK compilation after regenerating from the latest OpenAPI spec.

**POST/list response parsing**: Map fields (additionalProperties objects) were emitted as Map<String, Object>.fromJson(...), which is invalid Java. POST responses now use JsonUtil.parseJsonObjectToMap, aligned with GET responses and list item parsing.

**FailedUsageEvent package**: The model was incorrectly treated as a webhook event and generated under models.event, while list responses import models.failedUsageEvent. FailedUsageEvent is now excluded from webhook classification, like UsageEvent and OfferEvent.