### PR TITLE
Exclude GET operations from JSON input flag checks in Action

### DIFF
--- a/src/main/java/com/chargebee/openapi/Action.java
+++ b/src/main/java/com/chargebee/openapi/Action.java
@@ -308,6 +308,12 @@ public class Action {
   }
 
   public boolean isOperationNeedsJsonInput() {
+    if (httpRequestType == HttpRequestType.GET) {
+      return false;
+    }
+    if (operation.getExtensions() == null) {
+      return false;
+    }
     Object isOperationNeedsJsonInput = operation.getExtensions().get(IS_OPERATION_NEEDS_JSON_INPUT);
     if (isOperationNeedsJsonInput == null) {
       return false;
@@ -454,9 +460,7 @@ public class Action {
   }
 
   public boolean isContentTypeJsonAction() {
-    return operation.getExtensions() != null
-        && operation.getExtensions().get(Extension.IS_OPERATION_NEEDS_JSON_INPUT) != null
-        && ((boolean) operation.getExtensions().get(Extension.IS_OPERATION_NEEDS_JSON_INPUT));
+    return isOperationNeedsJsonInput();
   }
 
   public boolean isIdempotent() {


### PR DESCRIPTION
## Summary

- `isOperationNeedsJsonInput()` now returns `false` for GET operations, since GET actions use query parameters rather than JSON request bodies.
- `isContentTypeJsonAction()` delegates to `isOperationNeedsJsonInput()` so both methods stay consistent and share the same GET guard and extension lookup logic.
- Adds a null-safe check on operation extensions before reading `x-cb-is-operation-needs-json-input`.

## Test plan

- [x] `./gradlew test --tests "com.chargebee.openapi.ActionTest"`
- [ ] Verify generated SDK output for a GET operation that has `x-cb-is-operation-needs-json-input` set does not emit JSON request helpers
- [ ] Verify POST operations with the extension still generate JSON request paths as before


Made with [Cursor](https://cursor.com)