### PR TITLE
update enum dir path for php v4

### DIFF
--- a/src/main/java/com/chargebee/sdk/php/v4/generators/ResourceFileGenerator.java
+++ b/src/main/java/com/chargebee/sdk/php/v4/generators/ResourceFileGenerator.java
@@ -135,7 +135,8 @@ public class ResourceFileGenerator implements FileGenerator {
       String outputPath, String resourceName, List<com.chargebee.openapi.Enum> enums)
       throws IOException {
     List<FileOp> fileOps = new ArrayList<>();
-    String enumDirPath = outputPath + FORWARD_SLASH + resourceName + FORWARD_SLASH + ENUMS;
+    String enumDirPath =
+        outputPath + FORWARD_SLASH + resourceName + FORWARD_SLASH + PASCAL_CASE_ENUMS;
     fileOps.add(
         new FileOp.CreateDirectory(outputPath + FORWARD_SLASH + resourceName, PASCAL_CASE_ENUMS));
     String namespace =


### PR DESCRIPTION
# 🚀 Pull Request Template

## 📘 Description
So the create-dir path and the write-file path disagree on casing.

On macOS (case-insensitive filesystem), Enums and enums resolve to the same folder → it works locally.
On Linux CI (case-sensitive), the Enums directory exists but enums does not, so the file write throws NoSuchFileException 


<!-- Provide a concise and clear explanation of what this PR does. Focus on **what** and **why**, rather than **how**. For example: -->
<!-- "This PR introduces support for retry logic in generated Python SDKs, aligning with Chargebee’s latest API guidelines." -->

## 🧩 Related Issues / Tickets

<!-- Reference any related issues or feature requests. Use "Closes #..." to auto-close the issue on merge. -->
Closes #IssueNumber

## 📂 Type of Change

<!-- Select all that apply -->
- [ ] ✨ Feature  
- [ ] 🐛 Bug Fix  
- [ ] 📝 Documentation  
- [ ] 🧪 Test Improvement  
- [ ] 🔧 Refactor / Code Cleanup  
- [ ] ⚙️ Build / Tooling  

## 🧪 How to Test

<!-- Briefly describe how reviewers can test your changes. Include setup steps, CLI commands, or code snippets where relevant. -->

```bash
# Example:
./gradlew run --args="-i spec.json -l PHP_V4 -o ../chargebee-php/php/src"