### PR TITLE
fix(validator-zod): stop dropping list actions and fix regex escaping

### DIFF
--- a/src/main/java/com/chargebee/sdk/validator/ast/js/TsPrinter.java
+++ b/src/main/java/com/chargebee/sdk/validator/ast/js/TsPrinter.java
@@ -122,7 +122,13 @@ public class TsPrinter {
 
   private String printLiteral(JsNode.Literal l) {
     if (l.value() == null) return "null";
-    if (l.value() instanceof String s) return "'" + s.replace("'", "\\'") + "'";
+    if (l.value() instanceof String s) {
+      // Escape backslashes first, then single quotes. Without escaping backslashes a regex
+      // pattern such as ^\d{10}$ would be emitted as RegExp('^\d{10}$'); in a JS string literal
+      // `\d` collapses to `d`, silently corrupting the pattern (e.g. \[ -> [, \d -> d).
+      String escaped = s.replace("\\", "\\\\").replace("'", "\\'");
+      return "'" + escaped + "'";
+    }
     if (l.value() instanceof Boolean b) return b.toString();
     return l.value().toString();
   }

--- a/src/main/java/com/chargebee/sdk/validator/emitter/zod/ZodTsEmitter.java
+++ b/src/main/java/com/chargebee/sdk/validator/emitter/zod/ZodTsEmitter.java
@@ -56,7 +56,7 @@ public class ZodTsEmitter implements ValidatorEmitter {
         Schema<?> bodySchema = resolveBodySchema(action, spec);
         if (bodySchema == null) continue;
 
-        ValidationNode irNode = irBuilder.buildNode(bodySchema, new HashSet<>());
+        ValidationNode irNode = irBuilder.buildRootNode(bodySchema, new HashSet<>());
         ValidationNode.ObjectNode rootObj = ensureObject(irNode);
         if (rootObj == null) continue;
 

--- a/src/main/java/com/chargebee/sdk/validator/ir/ValidationIRBuilder.java
+++ b/src/main/java/com/chargebee/sdk/validator/ir/ValidationIRBuilder.java
@@ -32,6 +32,29 @@ public class ValidationIRBuilder {
   }
 
   /**
+   * Build the IR node for the <em>top-level</em> schema of an action's request body or GET query
+   * parameters.
+   *
+   * <p>The root schema is always a parameter container and must be emitted as an object. The
+   * {@code x-cb-is-multi-value-attribute} heuristic (see {@link #buildMultiValueObjectNode}) is
+   * meant for <em>nested</em> flat-array params such as {@code subscription_items[item_price_id][0]},
+   * where a named child property logically represents an array of objects. It must never be applied
+   * to the root container itself: list filter params ({@code id}, {@code name}, {@code status}, …)
+   * and several {@code /exports/*} body params carry that flag, and flattening the whole container
+   * into an {@code ArrayNode} causes the emitter to discard the action entirely. Recursion into
+   * child properties still applies the heuristic normally, so legitimate nested multi-value params
+   * are unaffected.
+   */
+  public ValidationNode buildRootNode(Schema<?> schema, Set<String> visiting) {
+    if (schema != null
+        && schema.get$ref() == null
+        && ("object".equals(schema.getType()) || schema instanceof ObjectSchema)) {
+      return buildObjectNode(schema, visiting, true);
+    }
+    return buildNode(schema, visiting);
+  }
+
+  /**
    * Build an IR node from an OpenAPI schema. Resolves $refs, handles objects, arrays, and
    * primitives. Uses {@code visiting} to break circular references.
    */
@@ -93,10 +116,16 @@ public class ValidationIRBuilder {
   }
 
   private ValidationNode buildObjectNode(Schema<?> schema, Set<String> visiting) {
+    return buildObjectNode(schema, visiting, false);
+  }
+
+  private ValidationNode buildObjectNode(
+      Schema<?> schema, Set<String> visiting, boolean skipMultiValueFlatten) {
     Map<String, Schema> properties = schema.getProperties();
 
-    // Check for multi-value attributes – flatten into ArrayNode<ObjectNode>
-    if (hasMultiValueAttributes(properties)) {
+    // Check for multi-value attributes – flatten into ArrayNode<ObjectNode>.
+    // Skipped at the root container level (see buildRootNode).
+    if (!skipMultiValueFlatten && hasMultiValueAttributes(properties)) {
       return buildMultiValueObjectNode(schema, visiting);
     }
 

--- a/src/test/java/com/chargebee/sdk/validator/ValidatorZodTests.java
+++ b/src/test/java/com/chargebee/sdk/validator/ValidatorZodTests.java
@@ -41,6 +41,11 @@ public class ValidatorZodTests extends LanguageTests {
       (MapEntry<String, Schema<?>>)
           (MapEntry<?, ?>) buildResource("token").withAttribute("id", true).done();
 
+  @SuppressWarnings("unchecked")
+  private static final MapEntry<String, Schema<?>> COUPON_CODE =
+      (MapEntry<String, Schema<?>>)
+          (MapEntry<?, ?>) buildResource("coupon_code").withAttribute("code", true).done();
+
   // ---- subject under test --------------------------------------------------
 
   private static ValidatorZod validatorZod;
@@ -139,6 +144,50 @@ public class ValidatorZodTests extends LanguageTests {
         .contains("limit: z.number().int().optional()")
         .contains("status: z.string()")
         .doesNotContain("status: z.string().optional()");
+  }
+
+  @Test
+  void shouldEmitListValidatorWhenFilterParamIsMultiValueAttribute() throws IOException {
+    // Regression: Chargebee list filter params (e.g. CouponCode.list `code`, `coupon_id`) are
+    // type=object operator schemas flagged with x-cb-is-multi-value-attribute. That flag previously
+    // caused the IR builder to flatten the whole synthetic query-params container into an
+    // ArrayNode, which the emitter then discarded (ensureObject == null) — dropping the entire
+    // `list` action. The root container must stay an object; each filter must become a nested
+    // operator object.
+    var codeFilter =
+        new ObjectSchema()
+            .addProperty("is", new StringSchema().minLength(1))
+            .addProperty("in", new StringSchema().pattern("^\\[(.*)(,.*)*\\]$"));
+    codeFilter.addExtension(Extension.IS_MULTI_ATTRIBUTE, true);
+
+    var listOp =
+        buildListOperation("list")
+            .forResource("coupon_code")
+            .withResponse(resourceResponseParam("coupon_code", COUPON_CODE))
+            .withQueryParam("limit", new IntegerSchema(), false)
+            .withQueryParam("code", codeFilter, false)
+            .withSortOrder(1)
+            .done();
+
+    var spec =
+        buildSpec().withResource(COUPON_CODE).withOperation("/coupon_codes", listOp).done();
+
+    List<FileOp> fileOps = validatorZod.generate("/validators", spec);
+
+    // The action must no longer be silently dropped: the resource schema file is emitted.
+    assertThat(fileOps).hasSize(3);
+    String src = findFileContent(fileOps, "coupon_code.schema.ts");
+    assertThat(src)
+        .contains("// Generated Zod schemas: CouponCode")
+        .contains("// Actions: list")
+        // root stays an object container, not an array
+        .contains("const ListCouponCodeBodySchema = z.looseObject({")
+        // the multi-value filter param becomes a nested operator object
+        .contains("const ListCouponCodeCodeSchema = z.object({")
+        .contains("is: z.string().min(1).optional()")
+        .contains("in: z.string().regex(")
+        .contains("code: ListCouponCodeCodeSchema.optional()")
+        .contains("limit: z.number().int().optional()");
   }
 
   // =========================================================================
@@ -302,6 +351,8 @@ public class ValidatorZodTests extends LanguageTests {
             .withResponse(resourceResponseParam("customer", CUSTOMER))
             .withRequestBody("name", new StringSchema().maxLength(100).minLength(1))
             .withRequestBody("code", new StringSchema().pattern("^[A-Z]+$"))
+            // backslash-containing pattern must keep its backslashes in the emitted string literal
+            .withRequestBody("ts", new StringSchema().pattern("^\\d{10}$"))
             .withSortOrder(0)
             .done();
 
@@ -311,7 +362,10 @@ public class ValidatorZodTests extends LanguageTests {
 
     assertThat(src)
         .contains("name: z.string().max(100).min(1).optional()")
-        .contains("code: z.string().regex(RegExp('^[A-Z]+$')).optional()");
+        .contains("code: z.string().regex(RegExp('^[A-Z]+$')).optional()")
+        // Regression: the backslash must be doubled in the emitted JS string literal so that
+        // RegExp(...) parses to /^\d{10}$/ at runtime rather than the corrupted /^d{10}$/.
+        .contains("ts: z.string().regex(RegExp('^\\\\d{10}$')).optional()");
   }
 
   @Test


### PR DESCRIPTION
Two correctness bugs in the Zod validator generator:

- The x-cb-is-multi-value-attribute heuristic was applied to the top-level body/query container, collapsing it into an ArrayNode so the emitter discarded the whole action. This dropped ~30 list actions (e.g. CouponCode.list) and several /exports/* POST actions. The root container is now always emitted as an object via buildRootNode; nested multi-value flattening is unaffected.
- TsPrinter escaped single quotes but not backslashes, corrupting every emitted .regex(RegExp('...')) (e.g. ^\d{10}$ became /^d{10}$/). String literals now escape backslashes too.

Adds regression tests for both.

# 🚀 Pull Request Template

## 📘 Description

<!-- Provide a concise and clear explanation of what this PR does. Focus on **what** and **why**, rather than **how**. For example: -->
<!-- "This PR introduces support for retry logic in generated Python SDKs, aligning with Chargebee’s latest API guidelines." -->

## 🧩 Related Issues / Tickets

<!-- Reference any related issues or feature requests. Use "Closes #..." to auto-close the issue on merge. -->
Closes #IssueNumber

## 📂 Type of Change

<!-- Select all that apply -->
- [ ] ✨ Feature  
- [ ] 🐛 Bug Fix  
- [ ] 📝 Documentation  
- [ ] 🧪 Test Improvement  
- [ ] 🔧 Refactor / Code Cleanup  
- [ ] ⚙️ Build / Tooling  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes two Zod generator correctness bugs: root request/query schemas now always emit as objects instead of collapsing multi-value containers, preserving affected actions; and TypeScript string literals now escape backslashes as well as quotes, preventing corrupted regex output. Added regression tests for both cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->