### PR TITLE
fix(go-v3): match dependent resource id by equals instead of contains

### DIFF
--- a/src/main/java/com/chargebee/sdk/go/v3/Go_V3.java
+++ b/src/main/java/com/chargebee/sdk/go/v3/Go_V3.java
@@ -212,7 +212,7 @@ public class Go_V3 extends Language {
       for (Attribute dr : getDependentResource(activeResource)) {
         var refModelName = singularize(dr.name.replace("_", ""));
         if (dr.isDependentAttribute()
-            && resourceList.stream().noneMatch(r -> r.id.contains(singularize(dr.name)))) {
+            && resourceList.stream().noneMatch(r -> r.id.equals(singularize(dr.name)))) {
           if (dr.subResourceName() != null) {
             refModelName = dr.subResourceName().toLowerCase();
           } else {


### PR DESCRIPTION
fix(go-v3): match dependent resource id by equals instead of contains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated Go v3 dependent-resource ID matching to use exact equality instead of substring containment, preventing incorrect filtering when one resource ID contains another.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->