### PR TITLE
fix(java): fully-qualify model enums that clash with java.util types

### DIFF
--- a/src/main/java/com/chargebee/sdk/java/Java.java
+++ b/src/main/java/com/chargebee/sdk/java/Java.java
@@ -151,8 +151,31 @@ public class Java extends Language {
     }
   }
 
+  private static final Set<String> JAVA_UTIL_TYPE_NAMES =
+      Set.of(
+          "Locale",
+          "Currency",
+          "Date",
+          "Calendar",
+          "TimeZone",
+          "Random",
+          "Timer",
+          "Formatter",
+          "Optional",
+          "Scanner",
+          "UUID",
+          "List",
+          "Map",
+          "Set",
+          "Queue",
+          "Stack",
+          "Vector",
+          "Comparator",
+          "Observable");
+
   private String qualifyEnumIfClashesWithResource(String enumApiName) {
-    if (activeResource != null && activeResource.name.equals(enumApiName)) {
+    if ((activeResource != null && activeResource.name.equals(enumApiName))
+        || (enumApiName != null && JAVA_UTIL_TYPE_NAMES.contains(enumApiName))) {
       return getEnumsPkg() + "." + enumApiName;
     }
     return enumApiName;


### PR DESCRIPTION
fix(java): fully-qualify model enums that clash with java.util types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated Java code generation to fully qualify enum references when their names clash with the active resource or `java.util` types, preventing naming conflicts in generated model code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->