### PR TITLE
fix(java-v4): rename inline list sub-model that collides with java.util.List

### DIFF
--- a/src/main/java/com/chargebee/sdk/java/v4/builder/ModelBuilder.java
+++ b/src/main/java/com/chargebee/sdk/java/v4/builder/ModelBuilder.java
@@ -149,7 +149,13 @@ public class ModelBuilder {
             || ((Schema) listSchema).getProperties().isEmpty()) {
           continue;
         }
-        subModels.add(createSubModel(fieldName.toString(), listSchema));
+        var subModel = createSubModel(fieldName.toString(), listSchema);
+        // Rename the inline class when the field-derived name collides with a Java built-in
+        // type (e.g. "list" -> "List"); use x-cb-sub-resource-name instead so it does not
+        // shadow the built-in type. Keeps the element type consistent with ListType/Field.
+        subModel.setName(
+            SchemaUtil.inlineItemClassName(fieldName.toString(), (Schema<?>) listSchema));
+        subModels.add(subModel);
       }
     }
     return subModels;

--- a/src/main/java/com/chargebee/sdk/java/v4/core/Field.java
+++ b/src/main/java/com/chargebee/sdk/java/v4/core/Field.java
@@ -147,14 +147,16 @@ public class Field {
         return items.get$ref().substring(items.get$ref().lastIndexOf("/") + 1);
       }
       if (items != null && items.getProperties() != null && !items.getProperties().isEmpty()) {
-        return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, listType.fieldName());
+        return com.chargebee.sdk.java.v4.util.SchemaUtil.inlineItemClassName(
+            listType.fieldName(), items);
       }
       if (items != null && "object".equals(items.getType())) {
         // If it's a free-form object (no properties), treat as Map
         if (items.getProperties() == null || items.getProperties().isEmpty()) {
           return "java.util.Map<String, Object>";
         }
-        return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, listType.fieldName());
+        return com.chargebee.sdk.java.v4.util.SchemaUtil.inlineItemClassName(
+            listType.fieldName(), items);
       }
 
       // Items with no type specified → generic array, matching List<Object> from display()

--- a/src/main/java/com/chargebee/sdk/java/v4/datatype/ListType.java
+++ b/src/main/java/com/chargebee/sdk/java/v4/datatype/ListType.java
@@ -2,7 +2,6 @@ package com.chargebee.sdk.java.v4.datatype;
 
 import static com.chargebee.openapi.Extension.IS_MONEY_COLUMN;
 
-import com.google.common.base.CaseFormat;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import org.jetbrains.annotations.NotNull;
@@ -44,7 +43,7 @@ public record ListType(String fieldName, Schema schema) implements FieldType {
       if (items.getProperties() != null && !items.getProperties().isEmpty()) {
         String className =
             fieldName != null
-                ? CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, fieldName)
+                ? com.chargebee.sdk.java.v4.util.SchemaUtil.inlineItemClassName(fieldName, items)
                 : "Object";
         return "List<" + className + ">";
       }

--- a/src/main/java/com/chargebee/sdk/java/v4/util/SchemaUtil.java
+++ b/src/main/java/com/chargebee/sdk/java/v4/util/SchemaUtil.java
@@ -44,6 +44,61 @@ public class SchemaUtil {
     return false;
   }
 
+  /**
+   * Java built-in / language type names that must not be used as generated (sub-)model class names,
+   * because doing so shadows the real type (e.g. an inner class named {@code List} shadows
+   * {@code java.util.List}). Add more names here manually as new collisions are discovered.
+   */
+  private static final java.util.Set<String> RESERVED_TYPE_NAMES = java.util.Set.of("List");
+
+  /**
+   * Returns true if the given class name collides with a Java built-in type and therefore cannot be
+   * used as a generated class name.
+   */
+  public static boolean isReservedTypeName(String name) {
+    return name != null && RESERVED_TYPE_NAMES.contains(name);
+  }
+
+  /**
+   * Reads the {@code x-cb-sub-resource-name} extension from a schema.
+   *
+   * @param schema the schema to inspect
+   * @return the sub-resource name (e.g. "AsyncResponse"), or null if absent
+   */
+  public static String subResourceName(Schema<?> schema) {
+    if (schema == null || schema.getExtensions() == null) {
+      return null;
+    }
+    Object subResourceName = schema.getExtensions().get(Extension.SUB_RESOURCE_NAME);
+    if (subResourceName instanceof String && !((String) subResourceName).isEmpty()) {
+      return (String) subResourceName;
+    }
+    return null;
+  }
+
+  /**
+   * Resolves the class name for an inline object (used for list items / sub-models). Normally this
+   * is the UpperCamel form of the field name, but when that collides with a Java built-in type
+   * (e.g. "list" -&gt; "List"), the {@code x-cb-sub-resource-name} is used instead so the generated
+   * class does not shadow the built-in type.
+   *
+   * @param fieldName the property name driving the class name
+   * @param itemSchema the inline object schema (source of x-cb-sub-resource-name)
+   * @return the class name to use for the generated inline class
+   */
+  public static String inlineItemClassName(String fieldName, Schema<?> itemSchema) {
+    String candidate =
+        com.google.common.base.CaseFormat.LOWER_UNDERSCORE.to(
+            com.google.common.base.CaseFormat.UPPER_CAMEL, fieldName);
+    if (isReservedTypeName(candidate)) {
+      String subResourceName = subResourceName(itemSchema);
+      if (subResourceName != null) {
+        return subResourceName;
+      }
+    }
+    return candidate;
+  }
+
   private SchemaUtil() {
     // Utility class, prevent instantiation
   }


### PR DESCRIPTION
## 📘 Description

The Java V4 generator derives an inline list sub-model's class name from the **field name**. For the `AsyncResponseList` resource this produced a nested class named `List` for the `list` array field, which **shadows `java.util.List`** and generated uncompilable code:

```java
// before (does not compile)
private List<List> list;
obj.list = JsonUtil.mapArray(JsonUtil.getJsonArray(jsonObj, "list"), List::fromJson);

public static class List { ... }
```

This PR makes the generator detect when a field-derived inline class name collides with a Java built-in type and, in that case only, fall back to the schema's `x-cb-sub-resource-name` for the class name:

```java
// after
private List<AsyncResponse> list;
obj.list = JsonUtil.mapArray(JsonUtil.getJsonArray(jsonObj, "list"), AsyncResponse::fromJson);

public static class AsyncResponse { ... }
```

The set of reserved names is intentionally minimal (currently just `List`) and is meant to be extended manually as new collisions surface.

### What changed
- **`util/SchemaUtil.java`** — added `RESERVED_TYPE_NAMES` (currently `{"List"}`), plus helpers `isReservedTypeName(...)`, `subResourceName(...)`, and `inlineItemClassName(fieldName, itemSchema)` which returns the UpperCamel field name normally, or the `x-cb-sub-resource-name` when it collides with a built-in type.
- **`datatype/ListType.java`** — inline-object element type now resolves via `inlineItemClassName(...)` (removed the now-unused `CaseFormat` import).
- **`core/Field.java`** — `getListElementType()` resolves via `inlineItemClassName(...)` so the correct `<Type>::fromJson` is emitted.
- **`builder/ModelBuilder.java`** — the generated inline sub-model is renamed via `inlineItemClassName(...)` so the nested class matches the element type.

Only the collision path is affected; all other inline list sub-models keep their existing field-derived names.

## 🧩 Related Issues / Tickets

N/A

## 📂 Type of Change

- [ ] ✨ Feature  
- [x] 🐛 Bug Fix  
- [ ] 📝 Documentation  
- [ ] 🧪 Test Improvement  
- [ ] 🔧 Refactor / Code Cleanup  
- [ ] ⚙️ Build / Tooling  

## 🧪 How to Test

```bash
# Regenerate the Java V4 SDK
./gradlew run --args="-i /path/to/chargebee_sdk_spec.json -l JAVA_V4 -o /path/to/chargebee-java/src/main/java/"
```

Then verify:
- `com/chargebee/v4/models/asyncResponseList/AsyncResponseList.java` uses `List<AsyncResponse>` (not `List<List>`) with a nested `AsyncResponse` class and `AsyncResponse::fromJson`.
- The generated `chargebee-java` project compiles (`./gradlew compileJava`).
- Generator tests pass: `./gradlew test --tests 'com.chargebee.sdk.java.v4.*'`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes Java V4 generation for inline list sub-models named `List`, preventing collisions with `java.util.List`. Centralized reserved-name handling uses `x-cb-sub-resource-name` consistently across generated element types, deserialization references, and nested classes. Other inline list naming remains unchanged; regenerated SDK compilation and generator tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->