### PR TITLE
 fix(go,dotnet): scope local list-of-enum types to their resource

### DIFF
--- a/src/main/java/com/chargebee/sdk/common/AttributeAssistant.java
+++ b/src/main/java/com/chargebee/sdk/common/AttributeAssistant.java
@@ -49,7 +49,7 @@ public class AttributeAssistant {
   public List<Attribute> resourceEnum() {
     return resource.attributes().stream()
         .filter(Attribute::isNotHiddenAttribute)
-        .filter(att -> att.isApi() && !att.isGenSeparate())
+        .filter(att -> (att.isApi() || att.itemsIsApi()) && !att.isGenSeparate())
         .toList();
   }
 

--- a/src/main/java/com/chargebee/sdk/go/v3/Go_V3.java
+++ b/src/main/java/com/chargebee/sdk/go/v3/Go_V3.java
@@ -787,7 +787,7 @@ public class Go_V3 extends Language {
                       getJsonVal(attribute, req)));
       } else if (attribute.isEnumAttribute() && !attribute.isFilterAttribute()) {
         if (attribute.isListOfEnum()) {
-          type = "[]enum." + getListOfEnumTypeForAttribute(attribute);
+          type = getListOfEnumTypeForAttribute(attribute);
         } else if (attribute.isGenSeparate()) {
           type = Constants.ENUM_WITH_DELIMITER + toClazName(attribute.name);
         } else {
@@ -872,7 +872,7 @@ public class Go_V3 extends Language {
       }
       if (a.isEnumAttribute()) {
         if (a.isListOfEnum()) {
-          type = "[]" + Constants.ENUM_WITH_DELIMITER + getListOfEnumTypeForAttribute(a);
+          type = getListOfEnumTypeForAttribute(a);
         } else if (a.isGenSeparate() || a.isGlobalEnumAttribute()) {
           type =
               Constants.ENUM_WITH_DELIMITER
@@ -934,7 +934,12 @@ public class Go_V3 extends Language {
   }
 
   private String getListOfEnumTypeForAttribute(Attribute a) {
-    return (String) a.getSchema().getItems().getExtensions().get(SDK_ENUM_API_NAME);
+    if(a.isExternalEnum() || a.isGenSeparate()) {
+      return "[]" + Constants.ENUM_WITH_DELIMITER + (String) a.getSchema().getItems().getExtensions().get(SDK_ENUM_API_NAME);
+    }
+    return getCamelClazName(activeResource.name)
+            + Constants.ENUM_DOT
+            + CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, a.name);
   }
 
   public String getSubResourceCols(Resource subResource) {

--- a/src/main/java/com/chargebee/sdk/go/v4/Go_V4.java
+++ b/src/main/java/com/chargebee/sdk/go/v4/Go_V4.java
@@ -1058,7 +1058,10 @@ public class Go_V4 extends Language {
   }
 
   private String getListOfEnumTypeForAttribute(Attribute a) {
-    return (String) a.getSchema().getItems().getExtensions().get(SDK_ENUM_API_NAME);
+    if (a.isExternalEnum() || a.isGenSeparate()){
+      return (String) a.getSchema().getItems().getExtensions().get(SDK_ENUM_API_NAME);
+    }
+    return activeResource.name + CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, a.name);
   }
 
   public String getSubResourceCols(Resource subResource) {


### PR DESCRIPTION
 fix(go,dotnet): scope local list-of-enum types to their resource

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates Go and .NET code generation to correctly scope local list-of-enum types to their associated resource. Enum discovery now includes item API attributes, while Go v3/v4 generators use resource-local enum references unless enums are external or generated separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->