### PR TITLE
Build and run generator with UTF-8 encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,13 @@ apply plugin : "java"
 group 'com.chargebee'
 version '1.0-SNAPSHOT'
 
+// Force UTF-8 for compilation so sources with non-ASCII characters (arrows,
+// em dashes, emoji in CLI messages/JavaDoc) build on runners whose default
+// platform encoding is US-ASCII (otherwise: "unmappable character" errors).
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
 repositories {
     mavenCentral()
     maven {
@@ -35,6 +42,10 @@ dependencies {
 application {
     mainClass = "com.chargebee.Main"
     applicationDefaultJvmArgs = [
+        // Ensure the generator reads/writes files as UTF-8 regardless of the
+        // runner's platform encoding.
+        '-Dfile.encoding=UTF-8',
+        '-Dsun.jnu.encoding=UTF-8',
         '--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED',
         '--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED',
         '--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED',
@@ -50,6 +61,7 @@ application {
 
 test {
     useJUnitPlatform()
+    systemProperty 'file.encoding', 'UTF-8'
     testLogging {
         events "passed", "skipped", "failed"
     }


### PR DESCRIPTION
## Summary
`build.gradle` never set the compile encoding, so `javac` fell back to the runner's platform default (`US-ASCII`). Sources contain non-ASCII characters (arrows, em dashes, emoji in CLI messages/JavaDoc), which produced `error: unmappable character (0xE2) for encoding US-ASCII` on CI (e.g. the SDK release / code-sample-validation regen step).

- Set `options.encoding = 'UTF-8'` for all `JavaCompile` tasks.
- Add `-Dfile.encoding=UTF-8` / `-Dsun.jnu.encoding=UTF-8` to the application run JVM args and `file.encoding=UTF-8` to the test JVM, so generated files are written as UTF-8 regardless of runner locale.

## Verification
`LANG=C LC_ALL=C ./gradlew compileJava` (reproduces the US-ASCII default) now compiles clean; previously it failed with unmappable-character errors.

## Test plan
- [ ] CI build on an ASCII-locale runner compiles without unmappable-character errors
- [ ] `./gradlew run` generates SDKs with correct UTF-8 output

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Configured Gradle to use UTF-8 for Java compilation, application generator file I/O, and application and test JVMs. This prevents locale-dependent compilation failures and ensures generated files use UTF-8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->