### PR TITLE
fix(go): form-encode filter operator arrays as a single field

### DIFF
--- a/src/main/resources/templates/go/v3/util.go.hbs
+++ b/src/main/resources/templates/go/v3/util.go.hbs
@@ -42,6 +42,23 @@ func SerializeParams(params interface{}) *url.Values {
 	return body
 }
 
+// Filter operators whose value is the whole array, sent as a single field
+// (eg : updated_at[between] : ["1704067200","1717199999"]).
+var arrayOperators = map[string]bool{"in": true, "not_in": true, "between": true}
+
+func serializeArrayOperator(anArray []interface{}) string {
+	items := make([]string, 0, len(anArray))
+	for _, element := range anArray {
+		items = append(items, fmt.Sprintf("%v", element))
+	}
+	encoded, err := json.Marshal(items)
+	if err != nil {
+		fmt.Println(err.Error())
+		return ""
+	}
+	return string(encoded)
+}
+
 func parseMap(aMap, serParams map[string]interface{}, prefix string, idx string, paramTypes map[string]string) {
 	for key, val := range aMap {
 		switch value := val.(type) {
@@ -66,7 +83,18 @@ func parseMap(aMap, serParams map[string]interface{}, prefix string, idx string,
 				parseMap(val.(map[string]interface{}), serParams, key, "", paramTypes)
 			}
 		case []interface{}:
-			parseArray(val.([]interface{}), serParams, key, "", paramTypes)
+			operator := key
+			if prefix != "" {
+				key = prefix + "[" + key + "]"
+			}
+			if arrayOperators[operator] {
+				// An empty filter is not a filter, so leave it out of the request.
+				if len(value) > 0 {
+					serParams[key] = serializeArrayOperator(value)
+				}
+				continue
+			}
+			parseArray(value, serParams, key, "", paramTypes)
 		default:
 			if prefix != "" && idx != "" {
 				key = prefix + "[" + key + "]" + "[" + idx + "]"


### PR DESCRIPTION
## Summary

`templates/go/v3/util.go.hbs` index-encodes array-valued filter operators, so `updated_at[between]` is sent as `[between][0]` / `[between][1]` — which the API rejects with `param_wrong_value`. The same branch also drops the parent prefix when recursing into a nested array, losing the sub-resource path.

`chargebee-go` fixed this in v3.52.1 ([chargebee/chargebee-go#87](https://github.com/chargebee/chargebee-go/pull/87)), but the fix lives in `util.go`, which this template overwrites on every regen — so the bug comes straight back. The sample validator has kept failing on `export_subscription_ramps` with `Missing required form field: ramp[effective_from][between]` for exactly that reason, while go-v4 (which has no serializer template) passes. This ports the released patch so generated SDKs keep it.

Node, PHP and go-v4 need no equivalent change: their serializers exist only in the SDK repos, so those fixes already survive regen.

## Test plan

- [x] Regenerated the go v3 SDK from `chargebee_sdk_spec.json` with this template onto `chargebee-go@v3`, then ran the SDK's own suite: `go test ./tests/...` passes, including the `SerializeParams` regression cases for `between` and for arrays nested in a sub-resource.
- [x] Ran the generated `export_subscription_ramps` sample against a local echo server with that SDK: it sends `ramp[effective_from][between]=["1704067200","1717199999"]` as a single field, which is what the validator expects (it compares array elements as strings).
- [x] Confirmed the regenerated `util.go` is byte-identical to the released v3.52.1 `util.go` through the serializer section.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Go v3 utility template to JSON-encode non-empty `in`, `not_in`, and `between` arrays as single form fields. Preserved prefixes for nested arrays, omitted empty filters, and added serialization error handling. This prevents regeneration from reintroducing the filter encoding defect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->